### PR TITLE
Set initial modal header state to be visible

### DIFF
--- a/client/public/clientJS/wishCardModal.js
+++ b/client/public/clientJS/wishCardModal.js
@@ -10,6 +10,9 @@ $('#wishCardDonateModal').on('show.bs.modal', function (event) {
     const amazonURL = button[0].dataset.valueUrl;
     const modalBody = $('.modal-body');
 
+    // make sure header with close button is shown
+    $('.modal-header').show();
+
     const modalWarningMessage =
         `<div class="quick-font donate-modal" id="donateModalMsg-${wishCardId}">
         <h4 class="crayon-font donate-modal-title">Ready to reserve ${childName}'s wish for donation?</h4>


### PR DESCRIPTION
When the donate modal first launches, the header should always be visible as it contains the close button.

Resolves: DON-129