### PR TITLE
Wish card random display donated

### DIFF
--- a/server/db/repository/WishCardRepository.js
+++ b/server/db/repository/WishCardRepository.js
@@ -21,7 +21,7 @@ async function getAllWishCards() {
 
 async function getViewableWishCards(showDonated) {
   try {
-    const searchArray = [{ status: 'published' }, { status: 'draft' }];
+    const searchArray = [{ status: 'published' }];
     if (showDonated) {
       searchArray.push({ status: 'donated' });
     }

--- a/server/routes/wishCards.js
+++ b/server/routes/wishCards.js
@@ -464,8 +464,7 @@ router.get('/get/random', async (req, res) => {
     let wishcards = [];
     wishcards = await WishCardRepository.getWishCardsByStatus('published');
     if (!wishcards || wishcards.length < 6) {
-      const donatedWishCards = await WishCardRepository.getWishCardsByStatus('donated');
-      wishcards.push(...donatedWishCards);
+      wishcards = await WishCardRepository.getViewableWishCards(true);
     }
     wishcards.sort(() => Math.random() - 0.5);
     const requiredLength = 3 * Math.ceil(wishcards.length / 3);

--- a/server/routes/wishCards.js
+++ b/server/routes/wishCards.js
@@ -461,12 +461,13 @@ router.get('/donate/:id', redirectLogin, getByIdValidationRules(), redirectLogin
 router.get('/get/random', async (req, res) => {
   try {
     // let wishcards = await WishCardRepository.getAllWishCards();
-    let wishcards = await WishCardRepository.getWishCardsByStatus('published');
-    if (!wishcards) {
-      wishcards = [];
-    } else {
-      wishcards.sort(() => Math.random() - 0.5); // [wishcard object, wishcard object, wishcard object]
+    let wishcards = [];
+    wishcards = await WishCardRepository.getWishCardsByStatus('published');
+    if (!wishcards || wishcards.length < 6) {
+      const donatedWishCards = await WishCardRepository.getWishCardsByStatus('donated');
+      wishcards.push(...donatedWishCards);
     }
+    wishcards.sort(() => Math.random() - 0.5);
     const requiredLength = 3 * Math.ceil(wishcards.length / 3);
     const rem = requiredLength - wishcards.length;
     if (rem !== 0 && wishcards.length > 3) {


### PR DESCRIPTION
Slightly better than earlier method.

- Viewable Wishcard method
    - Removed returning draft wishcards (fn isn't used elsewhere, so safe to modify)
- Replaced earlier method (pushing donated wishcards) with getViewableWishcards
    - This should be more efficient than pushing all donated cards
    - Also limits fetching to only 25 cards or so.