### PR TITLE
fix: load env before route registration

### DIFF
--- a/services/website-api/src/app.ts
+++ b/services/website-api/src/app.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { config } from 'dotenv';
+import 'dotenv/config';
 import * as cors from 'cors';
 import * as path from 'path';
 import * as express from 'express';
@@ -16,17 +16,6 @@ import { connectSocket } from './helper/socket';
 import { RegisterRoutes } from './routes/routes';
 
 // load from config if not production, otherwise use from docker
-if (process.env.NODE_ENV !== 'production') {
-	let configPath = path.join(__dirname, '../../../config/config.env');
-
-	if (process.env.NODE_ENV === 'test') {
-		configPath = path.join(__dirname, '../../../config/test.config.env');
-	}
-
-	config({
-		path: configPath,
-	});
-}
 
 const app = express();
 

--- a/setup.md
+++ b/setup.md
@@ -4,6 +4,11 @@ We are using [lerna.js](https://lerna.js.org/) for mono repository setup and [ts
 
 Our custom packages are all prefixed with ```@donategifts```
 
+Make sure to use npm 7 otherwise you will encounter errors.
+You can install npm 7 with 
+
+`sudo npm install -g npm@7` 
+
 ---
 
 Inside the root directory
@@ -38,6 +43,10 @@ if you want to use a module that's already installed in another package add the 
 lerna link
 ```
 
+---
+If you need to add an npm package to our packages you have to manually add the package + version to the package.json of our package and run npm install in the root of the project
+
+---
 additionally you can add that package with lerna so that it will symlink it during the adding process
 
 ```bash


### PR DESCRIPTION
current setup would throw errors on start since config is loaded after route registration which clashes with the storage helper. this way would load the config from an .env file in /website-api