### PR TITLE
Added escapemarkup prop to toastify confing, default set to true

### DIFF
--- a/client/public/clientJS/loginToast.js
+++ b/client/public/clientJS/loginToast.js
@@ -6,7 +6,7 @@ $(window).on('load', function() {
     sessionStorage.setItem('LoginToastShow', 1);
   myLoginToast = setTimeout(function() {
     let msg = "<div class='loginToastReminder'>More features will be enabled if you log in. <span class='loginToastReminder__link'><a id='loginToastReminder__link__anchor' href=\"/users/signup\">Sign&nbsp;Up</a></span> or <span class='loginToastReminder__link'><a id='loginToastReminder__link__anchor' href=\"/users/login\">Login</a></span></div>"
-    showToast(msg, undefined, -1, { x: 0, y: '7em' }, 'loginToastReminder');
+    showToast(msg, undefined, -1, { x: 0, y: '7em' }, 'loginToastReminder', false);
     }, 90 * 1000);
   }
 });

--- a/client/public/clientJS/simpleToast.js
+++ b/client/public/clientJS/simpleToast.js
@@ -3,7 +3,7 @@
 
 // since we only change toast message
 // wrap it so there is less code around
-function showToast(message, success = false, duration= 3000, offset={x:0, y:0}, className= 'custom-toast') {
+function showToast(message, success = false, duration= 3000, offset={x:0, y:0}, className= 'custom-toast', escapeMarkup = true) {
   var color = success ? '#32a852' : '#8e4dff';
 
   //Login toast has duration of -1(displays until closed by user), styling is below for it.
@@ -21,6 +21,7 @@ function showToast(message, success = false, duration= 3000, offset={x:0, y:0}, 
     backgroundColor: `linear-gradient(to right, ${color}, ${color})`,
     stopOnFocus: true,
     className,
-    offset
+    offset,
+    escapeMarkup,
   }).showToast();
 }


### PR DESCRIPTION
Newer versions of toastify have added a markup prop. Before this was default set to false and it would not escape HTML. Later it was set to true by default and thats why HTML was displayed as a string. Added that prop and by default its set to true