### PR TITLE
#350/351: Wishcard validation + Redirect

### DIFF
--- a/server/routes/validations/wishcards.validations.js
+++ b/server/routes/validations/wishcards.validations.js
@@ -17,7 +17,7 @@ const createWishcardValidationRules = () => {
       .withMessage('Wish item url is required')
       .isString()
       // https://regex101.com/r/yM5lU0/13 if you want to see it in action
-      .matches(/^(https(:\/\/)){1}([w]{3})(\.amazon\.com){1}\/.*$/)
+      .matches(/^(https?(:\/\/)){1}([w]{3})(\.amazon\.com){1}\/.*$/)
       .withMessage('Wish item url has to be a valid amazon link!'),
     body('childStory').notEmpty().withMessage("Child's story is required").isString(),
     body('address1')

--- a/server/routes/wishCards.js
+++ b/server/routes/wishCards.js
@@ -105,7 +105,7 @@ router.post(
           ...req.body,
         });
 
-        res.status(200).send({ success: true, url: '/wishcards/' });
+        res.status(200).send({ success: true, url: '/wishcards/me' });
         log.info('Wishcard created', { type: 'wishcard_created', agency: userAgency._id, wishCardId: newWishCard._id });
       } catch (error) {
         handleError(res, 400, error);
@@ -174,7 +174,7 @@ router.post(
           ...req.body,
         });
 
-        res.status(200).send({ success: true, url: '/wishcards/' });
+        res.status(200).send({ success: true, url: '/wishcards/me' });
         log.info('Wishcard created', { type: 'wishcard_created', agency: userAgency._id, wishCardId: newWishCard._id });
       } catch (error) {
         handleError(res, 400, error);

--- a/test/wishcards.test.js
+++ b/test/wishcards.test.js
@@ -165,7 +165,7 @@ describe('Wishcard Routes - Authenticated & Verified Partner User', () => {
         res.body.should.have.property('success');
         res.body.should.have.property('url');
         res.body.success.should.equal(true);
-        res.body.url.should.equal('/wishcards/');
+        res.body.url.should.equal('/wishcards/me');
 
         WishCard.findOne({ childFirstName: wishcardRequest.childFirstName }).then((wishcard) => {
           wishcardRequest.wishItemName.should.equal(wishcard.wishItemName);
@@ -189,7 +189,7 @@ describe('Wishcard Routes - Authenticated & Verified Partner User', () => {
       });
   });
 
-  it('POST wishcards/guided - receives url - /wishcards', (done) => {
+  it('POST wishcards/guided - receives url - /wishcards/me', (done) => {
     agent
       .post('/wishcards/guided/')
       .type('form')
@@ -201,7 +201,7 @@ describe('Wishcard Routes - Authenticated & Verified Partner User', () => {
         res.body.should.have.property('success');
         res.body.should.have.property('url');
         res.body.success.should.equal(true);
-        res.body.url.should.equal('/wishcards/');
+        res.body.url.should.equal('/wishcards/me');
 
         WishCard.findOne({ childFirstName: guidedwishcardRequest.childFirstName }).then((wishcard) => {
           itemChoice.Name.should.equal(wishcard.wishItemName);

--- a/test/wishcards.test.js
+++ b/test/wishcards.test.js
@@ -189,6 +189,22 @@ describe('Wishcard Routes - Authenticated & Verified Partner User', () => {
       });
   });
 
+  it('POST /wishcards/ - Should also work with http amazon link', (done) => {
+    agent
+      .post('/wishcards/')
+      .type('form')
+      .field({ ...wishcardRequest, wishItemURL: 'http://www.amazon.com/asdf' })
+      .attach('wishCardImage', fs.readFileSync('client/public/img/card-sample-1.jpg'), 'card-sample1.jpg')
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.have.property('success');
+        res.body.should.have.property('url');
+        res.body.success.should.equal(true);
+        res.body.url.should.equal('/wishcards/me');
+        done();
+      });
+  });
+
   it('POST wishcards/guided - receives url - /wishcards/me', (done) => {
     agent
       .post('/wishcards/guided/')


### PR DESCRIPTION
#351 
#350 

Changed the redirect to wishcard/me/ + Changed wishcard validation to accept http or https amazon links.

On a side note: If we have some time, I would suggest modifying wishcard/me/ a bit (add editing functionality for partners - I don't think we had the time do that last time :+1: )

There's a PUT route for updating wishcard status (from admin panel), so we can reuse that if needed.