### PR TITLE
Add explicit return for response handlers

### DIFF
--- a/src/api/controller/agency.ts
+++ b/src/api/controller/agency.ts
@@ -22,7 +22,7 @@ export default class AgencyController extends BaseController {
 				return this.handleError(res, 'Agency could not be found');
 			}
 
-			this.sendResponse(res, agency);
+			return this.sendResponse(res, agency);
 		} catch (error) {
 			return this.handleError(res, error);
 		}

--- a/src/api/controller/community.ts
+++ b/src/api/controller/community.ts
@@ -52,7 +52,7 @@ export default class CommunityController extends BaseController {
 				(a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
 			);
 
-			this.sendResponse(res, posts);
+			return this.sendResponse(res, posts);
 		} catch (error: any) {
 			return this.handleError(res, error);
 		}

--- a/src/controller/admin.ts
+++ b/src/controller/admin.ts
@@ -63,7 +63,7 @@ export default class AdminController extends BaseController {
 				success: true,
 			});
 		} catch (error) {
-			this.handleError(res, error);
+			return this.handleError(res, error);
 		}
 	}
 

--- a/src/controller/basecontroller.ts
+++ b/src/controller/basecontroller.ts
@@ -39,12 +39,12 @@ export default class BaseController {
 		this.log.error(error);
 
 		if (renderErrorPage) {
-			res.status(statusCode).render(code === 400 ? '404' : code.toString(), {
+			return res.status(statusCode).render(code === 400 ? '404' : code.toString(), {
 				statusCode,
 				error,
 			});
 		} else {
-			res.status(statusCode).send({
+			return res.status(statusCode).send({
 				statusCode,
 				error,
 			});

--- a/src/controller/community.ts
+++ b/src/controller/community.ts
@@ -64,7 +64,7 @@ export default class CommunityController extends BaseController {
 				(a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
 			);
 
-			res.status(200).send({
+			return res.status(200).send({
 				posts,
 			});
 		} catch (error: any) {

--- a/src/controller/password.ts
+++ b/src/controller/password.ts
@@ -42,7 +42,7 @@ export default class PasswordController extends BaseController {
 
 			await Messaging.sendPasswordResetMail(userObject.email, resetToken);
 
-			res.send({ success: true });
+			return res.send({ success: true });
 		} catch (error) {
 			return this.handleError(res, error);
 		}
@@ -89,7 +89,7 @@ export default class PasswordController extends BaseController {
 						res.clearCookie(config.SESSION.NAME);
 					});
 
-					res.send({ success: true });
+					return res.send({ success: true });
 				} else {
 					return this.handleError(res, 'Password token expired');
 				}

--- a/src/controller/paymentProvider.ts
+++ b/src/controller/paymentProvider.ts
@@ -138,7 +138,7 @@ export default class PaymentProviderController extends BaseController {
 				},
 			});
 
-			res.send({
+			return res.send({
 				clientSecret: paymentIntent.client_secret,
 			});
 		} else {
@@ -171,7 +171,7 @@ export default class PaymentProviderController extends BaseController {
 					});
 				}
 			} catch (error) {
-				res.status(400).send(`Webhook Error: ${error}`);
+				return res.status(400).send(`Webhook Error: ${error}`);
 			}
 		}
 

--- a/src/controller/paymentProvider.ts
+++ b/src/controller/paymentProvider.ts
@@ -142,7 +142,7 @@ export default class PaymentProviderController extends BaseController {
 				clientSecret: paymentIntent.client_secret,
 			});
 		} else {
-			this.handleError(res, 'Wishcard not found');
+			return this.handleError(res, 'Wishcard not found');
 		}
 	}
 
@@ -201,7 +201,7 @@ export default class PaymentProviderController extends BaseController {
 			});
 		}
 
-		res.json({ received: true });
+		return res.json({ received: true });
 	}
 
 	async handleGetPaymentSuccess(req: Request, res: Response, _next: NextFunction) {

--- a/src/controller/profile.ts
+++ b/src/controller/profile.ts
@@ -87,7 +87,7 @@ export default class ProfileController extends BaseController {
 
 			await this.userRepository.updateUserById(user._id.toString(), { aboutMe });
 
-			res.status(200).send({
+			return res.status(200).send({
 				success: true,
 				error: null,
 				data: aboutMe,
@@ -121,7 +121,7 @@ export default class ProfileController extends BaseController {
 				user: res.locals.user._id,
 			});
 
-			res.status(200).send({
+			return res.status(200).send({
 				success: true,
 				data: profileImage,
 			});
@@ -138,7 +138,7 @@ export default class ProfileController extends BaseController {
 				profileImage: defaultImage,
 			});
 
-			res.status(200).send({
+			return res.status(200).send({
 				success: true,
 				data: defaultImage,
 			});
@@ -270,7 +270,7 @@ export default class ProfileController extends BaseController {
 
 			await this.userRepository.updateUserById(user._id, { fName, lName });
 
-			res.status(200).send({
+			return res.status(200).send({
 				success: true,
 				error: null,
 				data: { fName, lName },
@@ -314,7 +314,7 @@ export default class ProfileController extends BaseController {
 				},
 			});
 
-			res.status(200).send({
+			return res.status(200).send({
 				success: true,
 				error: null,
 				data: {
@@ -342,7 +342,7 @@ export default class ProfileController extends BaseController {
 				return this.handleError(res, 'Agency could not be found', 404);
 			}
 
-			res.status(200).send({
+			return res.status(200).send({
 				data: agency,
 			});
 		} catch (error) {

--- a/src/controller/profile.ts
+++ b/src/controller/profile.ts
@@ -146,18 +146,18 @@ export default class ProfileController extends BaseController {
 				profileImage: defaultImage,
 			});
 
-			return res.status(200).send({
-				success: true,
-				data: defaultImage,
-			});
-
 			this.log.info({
 				msg: 'Profile picture deleted',
 				type: 'user_profile_picture_delete',
 				user: res.locals.user._id,
 			});
+
+			return res.status(200).send({
+				success: true,
+				data: defaultImage,
+			});
 		} catch (error) {
-			this.handleError(res, error);
+			return this.handleError(res, error);
 		}
 	}
 

--- a/src/controller/wishcard.ts
+++ b/src/controller/wishcard.ts
@@ -172,7 +172,7 @@ export default class WishCardController extends BaseController {
 					wishCardId: newWishCard._id,
 				});
 
-				res.status(200).send({ success: true, url: '/wishcards/me' });
+				return res.status(200).send({ success: true, url: '/wishcards/me' });
 			} catch (error) {
 				this.handleError(res, error);
 			}
@@ -234,7 +234,7 @@ export default class WishCardController extends BaseController {
 					agency: userAgency?._id,
 					wishCardId: newWishCard._id,
 				});
-				res.status(200).send({ success: true, url: '/wishcards/me' });
+				return res.status(200).send({ success: true, url: '/wishcards/me' });
 			} catch (error) {
 				this.handleError(res, error);
 			}
@@ -298,7 +298,7 @@ export default class WishCardController extends BaseController {
 				wishCardId: wishcard?._id,
 			});
 
-			res.status(200).send({ success: true, url });
+			return res.status(200).send({ success: true, url });
 		} catch (error) {
 			this.handleError(res, error);
 		}
@@ -327,7 +327,7 @@ export default class WishCardController extends BaseController {
 				mgs: 'Wishcard Deleted',
 				wishCardId: wishcard?._id,
 			});
-			res.status(200).send({ success: true, url });
+			return res.status(200).send({ success: true, url });
 		} catch (error) {
 			this.handleError(res, error);
 		}
@@ -389,7 +389,7 @@ export default class WishCardController extends BaseController {
 				recentlyAdded,
 			);
 
-			res.status(200).send({
+			return res.status(200).send({
 				user: res.locals.user,
 				wishcards: results,
 			});
@@ -469,7 +469,7 @@ export default class WishCardController extends BaseController {
 				if (error) {
 					throw error;
 				} else {
-					res.status(200).send(html);
+					return res.status(200).send(html);
 				}
 			});
 		} catch (error) {
@@ -486,7 +486,7 @@ export default class WishCardController extends BaseController {
 				message,
 			});
 
-			res.status(200).send({
+			return res.status(200).send({
 				data: newMessage,
 			});
 		} catch (error) {
@@ -529,7 +529,7 @@ export default class WishCardController extends BaseController {
 			if (error) {
 				this.handleError(res, error);
 			} else {
-				res.status(200).send({ success: true, html });
+				return res.status(200).send({ success: true, html });
 			}
 		});
 	}

--- a/src/controller/wishcard.ts
+++ b/src/controller/wishcard.ts
@@ -174,7 +174,7 @@ export default class WishCardController extends BaseController {
 
 				return res.status(200).send({ success: true, url: '/wishcards/me' });
 			} catch (error) {
-				this.handleError(res, error);
+				return this.handleError(res, error);
 			}
 		}
 	}
@@ -236,7 +236,7 @@ export default class WishCardController extends BaseController {
 				});
 				return res.status(200).send({ success: true, url: '/wishcards/me' });
 			} catch (error) {
-				this.handleError(res, error);
+				return this.handleError(res, error);
 			}
 		}
 	}
@@ -259,9 +259,13 @@ export default class WishCardController extends BaseController {
 			const { agencyAddress } = agency;
 			const childBirthday = moment(wishcard?.childBirthday).format('YYYY-MM-DD');
 
-			this.renderView(res, 'wishcard/edit', { wishcard, agencyAddress, childBirthday });
+			return this.renderView(res, 'wishcard/edit', {
+				wishcard,
+				agencyAddress,
+				childBirthday,
+			});
 		} catch (error) {
-			this.handleError(res, error);
+			return this.handleError(res, error);
 		}
 	}
 
@@ -300,7 +304,7 @@ export default class WishCardController extends BaseController {
 
 			return res.status(200).send({ success: true, url });
 		} catch (error) {
-			this.handleError(res, error);
+			return this.handleError(res, error);
 		}
 	}
 
@@ -327,9 +331,10 @@ export default class WishCardController extends BaseController {
 				mgs: 'Wishcard Deleted',
 				wishCardId: wishcard?._id,
 			});
+
 			return res.status(200).send({ success: true, url });
 		} catch (error) {
-			this.handleError(res, error);
+			return this.handleError(res, error);
 		}
 	}
 
@@ -394,7 +399,7 @@ export default class WishCardController extends BaseController {
 				wishcards: results,
 			});
 		} catch (error) {
-			this.handleError(res, error);
+			return this.handleError(res, error);
 		}
 	}
 
@@ -490,7 +495,7 @@ export default class WishCardController extends BaseController {
 				data: newMessage,
 			});
 		} catch (error) {
-			this.handleError(res, error);
+			return this.handleError(res, error);
 		}
 	}
 
@@ -527,10 +532,10 @@ export default class WishCardController extends BaseController {
 
 		res.render('partials/itemChoices', { itemChoices }, (error, html) => {
 			if (error) {
-				this.handleError(res, error);
-			} else {
-				return res.status(200).send({ success: true, html });
+				return this.handleError(res, error);
 			}
+
+			return res.status(200).send({ success: true, html });
 		});
 	}
 }

--- a/src/helper/messaging.ts
+++ b/src/helper/messaging.ts
@@ -404,6 +404,7 @@ export default class Messaging {
 			});
 		} catch (error) {
 			log.error(error);
+			return;
 		}
 	}
 
@@ -450,6 +451,7 @@ export default class Messaging {
 			});
 		} catch (error) {
 			log.error(error);
+			return;
 		}
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,22 +155,22 @@ const app = express();
 
 	app.use('/robots.txt', limiter, (_req, res, _next) => {
 		res.type('text/plain');
-		res.sendFile(path.join(__dirname, '../public/robots.txt'));
+		return res.sendFile(path.join(__dirname, '../public/robots.txt'));
 	});
 
 	app.use('/health', (_req, res, _next) => {
-		res.status(200).json({ status: 'ok' });
+		return res.status(200).json({ status: 'ok' });
 	});
 
 	if (config.MAINTENANCE_ENABLED) {
 		app.get('*', (_req, res) => {
-			res.status(200).render('maintenance');
+			return res.status(200).render('maintenance');
 		});
 	}
 
 	// ERROR PAGE
 	app.get('*', (_req, res) => {
-		res.status(404).render('error/404');
+		return res.status(404).render('error/404');
 	});
 
 	// error handler
@@ -181,7 +181,7 @@ const app = express();
 
 		log.error(err);
 
-		res.status(500).render('error/500');
+		return res.status(500).render('error/500');
 	});
 
 	app.listen(config.PORT, () => {

--- a/src/middleware/validations.ts
+++ b/src/middleware/validations.ts
@@ -360,6 +360,7 @@ export default class Validations {
 		if (!errors.isEmpty()) {
 			return Validations.handleError(res, 400, errors);
 		}
-		next();
+
+		return next();
 	}
 }

--- a/src/middleware/validations.ts
+++ b/src/middleware/validations.ts
@@ -41,7 +41,7 @@ export default class Validations {
 			});
 		}
 
-		res.status(statusCode).send({
+		return res.status(statusCode).send({
 			statusCode,
 			error,
 		});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
         "esModuleInterop": true,
         "skipLibCheck": true,
         "noImplicitAny": false,
+        "noImplicitReturns": true,
         "allowSyntheticDefaultImports": true,
     },
     "files": [


### PR DESCRIPTION
Per [this](https://github.com/donategifts/donategifts/pull/581#discussion_r1282087648) discussion on PR #581, we would like to apply a blanket change to add explicit returns to all response handlers to ensure the call stack terminates without relying on the library functions to handle the exit themselves.

I've tested a majority of these routes and did not experience any unexpected or invalid behavior. We should also look into a linting rule that makes this a requirement if possible.