### PR TITLE
Fix: Messaging not working

### DIFF
--- a/views/pages/wishcard/single.pug
+++ b/views/pages/wishcard/single.pug
@@ -118,13 +118,16 @@ block scripts
             $('form').submit(function (event) {
                 event.preventDefault();
 
+                const messageFrom = !{JSON.stringify(user)};
+                const messageTo = !{JSON.stringify(wishcard)};
+
                 $.ajax({
                     type: 'POST',
                     url: '/wishcards/message',
                     data: {
-                        messageFrom: '#{user ? user._id : ''}',
-                        messageTo: '#{wishcard._id}',
-                        message: $('.custom-select option:selected').text(),
+                        messageFrom,
+                        messageTo,
+                        message: $('.form-select-lg option:selected').text(),
                     },
                     statusCode: {
                         400: function (response) {


### PR DESCRIPTION
- Frontend was passing in the user and wishcard Ids while backend was expecting the object.
   - Alternatively, could change the backend code (add in extra db calls for fetching user/wishcard in postMessageValidationRules and handlePostMessage) and just pass in the Ids from frontend.