### PR TITLE
Add validation for url protocol

### DIFF
--- a/src/controller/wishcard.ts
+++ b/src/controller/wishcard.ts
@@ -414,6 +414,9 @@ export default class WishCardController extends BaseController {
 
 			// this agency object is returning undefined and breaking frontend
 			const agency = wishcard!.belongsTo;
+
+			agency.agencyWebsite = Utils.ensureProtocol(agency.agencyWebsite);
+
 			const messages = await this.messageRepository.getMessagesByWishCardId(wishcard!._id);
 
 			const birthday = wishcard?.childBirthYear

--- a/src/helper/utils.ts
+++ b/src/helper/utils.ts
@@ -95,4 +95,11 @@ export default class Utils {
 		}
 		return match[1];
 	}
+
+	static ensureProtocol(url: string) {
+		if (!url.startsWith('http://') && !url.startsWith('https://')) {
+			return 'http://' + url;
+		}
+		return url;
+	}
 }


### PR DESCRIPTION
The issue was caused by not having a protocol component in the URL and thus the browser believing it to be a relative href tag. 

I added a static utility function as this seems to be the preferred approach in your codebase. There are a couple of other ways to do it so if you are unhappy with the implementation or modifying the agency object directly, let me know.

Lastly, I only updated the wishcard controller as it was the only page mentioned. A more robust fix would be to ensure that http:// is added when creating the agency but that would have wider implications so I'll let you decide whether or not to do that.