### PR TITLE
Fix typos and incorrect variable name

### DIFF
--- a/js/react/pages/admin/routes/wishcard/administration.jsx
+++ b/js/react/pages/admin/routes/wishcard/administration.jsx
@@ -9,11 +9,10 @@ export default function Administration() {
 
 	axios.defaults.baseURL = '/api/admin';
 
-	//NOTE: BUG: Editing the wishItemURL function does not work. It's either broken or incomplete.
 	const handleUpdateWishcard = async (wishCardId) => {
 		const newWishItemUrl = document.getElementById('newWishItemUrl' + wishCardId).value;
 		try {
-			await axios.put('/publishWishcards', { wishCardId, wishItemUr: newWishItemUrl }); //NOTE: there is a typo
+			await axios.put('/publishWishcards', { wishCardId, wishItemURL: newWishItemUrl });
 
 			fetchAgencyWithWishCardsData();
 		} catch (error) {

--- a/src/api/controller/admin.ts
+++ b/src/api/controller/admin.ts
@@ -190,9 +190,9 @@ export default class AdminController extends BaseController {
 
 	async handlePutDraftWishcard(req: Request, res: Response, _next: NextFunction) {
 		try {
-			const { wishCardId, wishItemUrl } = req.body;
+			const { wishCardId, wishItemURL } = req.body;
 			const wishCardModifiedFields = {
-				wishItemUrl,
+				wishItemURL,
 				status: 'published',
 			};
 


### PR DESCRIPTION
WishItemUrl was misspelled on frontend and had incorrect casing on backend which caused failure when updating wishcard url