### PR TITLE
Fixed google signup not showing after switching from partner to donor tab

### DIFF
--- a/js/react/pages/signup.jsx
+++ b/js/react/pages/signup.jsx
@@ -194,9 +194,12 @@ function Signup() {
 							>
 								Sign Up
 							</button>
-							{userRole === 'donor' && (
-								<div className="mt-3 center-elements" id="google-login-button" />
-							)}
+							<div
+								className={
+									(userRole === 'partner' && 'd-none') + ' mt-3 center-elements'
+								}
+								id="google-login-button"
+							/>
 						</div>
 					</div>
 				</form>


### PR DESCRIPTION
The Google signup button would not load if the user switched from the Nonprofit Agency tab to the Gift Sender tab. This occurred because the button was conditionally rendered. This caused the element to have to be initialized each time the user switched roles on the signup page. I fixed this by switching from conditionally rendering to adding the d-none class when the button shouldn't be displayed.