### PR TITLE
Fix error pages not showing in edge cases

### DIFF
--- a/src/controller/profile.ts
+++ b/src/controller/profile.ts
@@ -193,7 +193,7 @@ export default class ProfileController extends BaseController {
 		}
 
 		this.log.error(`Email verification failed for hash ${req.params.hash}!`);
-		return this.handleError(res, 'Email Verification failed!', 500);
+		return this.handleError(res, 'Email Verification failed!', 500, true);
 	}
 
 	async handlePutAccount(req: Request, res: Response, _next: NextFunction) {

--- a/src/controller/wishcard.ts
+++ b/src/controller/wishcard.ts
@@ -447,7 +447,7 @@ export default class WishCardController extends BaseController {
 				defaultMessages: defaultMessages || [],
 			});
 		} catch (error) {
-			this.handleError(res, error);
+			this.handleError(res, error, 404, true);
 		}
 	}
 
@@ -479,7 +479,7 @@ export default class WishCardController extends BaseController {
 				agency,
 			});
 		} catch (error) {
-			this.handleError(res, error);
+			this.handleError(res, error, 404, true);
 		}
 	}
 


### PR DESCRIPTION
In some cases when invalid data is passed as a URL parameter the error pages won't show and the user will be given a plain-text/JSON error. This is because the error-handling functions didn't have the `renderErrorPage` param set to true. I set this to true in all the broken error routes I could find. If any more broken routes are found they can be fixed using the method I used.

Closes #784 


