### PR TITLE
fix: fixed donation history table

### DIFF
--- a/js/react/pages/profile/donationhistory.jsx
+++ b/js/react/pages/profile/donationhistory.jsx
@@ -2,6 +2,7 @@ import { Table } from '@mantine/core';
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 
+import CustomToast from '../../components/shared/CustomToast.jsx';
 import PopOver from '../../components/shared/PopOver.jsx';
 import Translations from '../../translations/en/profile.json';
 import MantineProviderWrapper from '../../utils/mantineProviderWrapper.jsx';
@@ -10,17 +11,21 @@ function DonationHistory() {
 	const [donations, setDonations] = useState([]);
 	const [totalDonation, setTotalDonation] = useState(0.0);
 	const [totalGifts, setTotalGifts] = useState(0);
+	const [showToast, setShowToast] = useState(false);
 	const dateConfig = { year: 'numeric', month: 'short', day: '2-digit' };
 
 	useEffect(() => {
-		const fetchDonations = () => {
-			axios.get('/api/profile/donations').then((res) => {
+		axios
+			.get('/api/profile/donations')
+			.then((res) => {
 				if (res.data && res.data.data) {
 					setDonations(res.data.data);
 				}
+			})
+			.catch((err) => {
+				console.error(err);
+				setShowToast(true);
 			});
-		};
-		fetchDonations();
 	}, []);
 
 	useEffect(() => {
@@ -36,6 +41,13 @@ function DonationHistory() {
 
 	return (
 		<MantineProviderWrapper>
+			{showToast && (
+				<CustomToast
+					message="Failed to fetch donations!"
+					type="error"
+					delayCloseForSeconds={3}
+				/>
+			)}
 			<div className="container mt-3" id="donation-history">
 				<div className="row p-4">
 					<div className="col-md-4">
@@ -106,7 +118,7 @@ function DonationHistory() {
 						</Table.Tr>
 					</Table.Thead>
 					<Table.Tbody>
-						{donations.length > 1
+						{donations.length
 							? donations.map((data) => (
 									<Table.Tr key={data?._id}>
 										<Table.Td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"cookie-parser": "1.4.6",
 				"cors": "2.8.5",
 				"dotenv": "16.3.1",
-				"embla-carousel-autoplay": "^7.1.0",
+				"embla-carousel-autoplay": "7.1.0",
 				"express": "4.18.2",
 				"express-mongo-sanitize": "2.2.0",
 				"express-rate-limit": "7.1.2",


### PR DESCRIPTION
the table was hidden because the condition to render it was set to `donations.length > 1`

resolves #764 764